### PR TITLE
Include nds_yn.h in nds_win.c for nds_yn_function definition

### DIFF
--- a/sys/nds/arm9/src/nds_win.c
+++ b/sys/nds/arm9/src/nds_win.c
@@ -17,6 +17,7 @@
 #include "nds_map.h"
 #include "nds_getlin.h"
 #include "nds_config.h"
+#include "nds_yn.h"
 
 #include "nds_kbd.h"
 #include "ppm-lite.h"


### PR DESCRIPTION
- Otherwise the build fails at nds_win.c.

Looks like the header was forgotten when nds_yn was moved.
