### PR TITLE
Fixed typo in name prompt

### DIFF
--- a/sys/nds/arm9/src/nds_win.c
+++ b/sys/nds/arm9/src/nds_win.c
@@ -1936,7 +1936,7 @@ void nds_askname()
   }
 
   while (! *plname) {
-    getlin("Enter You Name:", plname);
+    getlin("Enter Your Name:", plname);
   }
 }
 


### PR DESCRIPTION
Changed "Enter You Name:" to "Enter Your Name:" when you first start
the game.
